### PR TITLE
Keep screen on while terminal session is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to the LinuxOnAndroid project will be documented in this fil
 - **Android 13+ Notification Permission (`POST_NOTIFICATIONS`)**: Added automatic runtime permission prompt on modern Android versions (API 33+) ensuring persistent service notifications and live resource status are visible in the status bar.
 - **Live Service Status & Resource Monitoring**: Displays active container status (e.g., `SSH :2222 | VNC :5901 • RAM: 140MB`) in the persistent Android notification shade with quick actions to "Open Terminal" or "Stop Session".
 - **Dedicated Background Execution Settings**: Configurable in its own dedicated card and filter category under Settings > Background Execution with instant start/stop lifecycle management and real-time protection summary.
+- **Keep Screen On While Terminal Is Active (Issue #25)**: Added a screen keep-alive tied to the terminal view, so the display no longer times out mid-session while watching long builds, log output, or interactive SSH work. Configurable under Settings > Background Execution and enabled by default.
 
 
 ## [1.2.0] - 2026-08-14

--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainAppContent.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainAppContent.kt
@@ -174,13 +174,15 @@ fun MainAppContent(viewModel: MainViewModel) {
                         val defaultUser by viewModel.defaultTerminalUser.collectAsState()
                         val fontSize by viewModel.terminalFontSize.collectAsState()
                         val fontFamily by viewModel.terminalFontFamily.collectAsState()
+                        val isKeepScreenOnEnabled by viewModel.isKeepScreenOnEnabled.collectAsState()
                         TerminalScreen(
                             terminalBridge = viewModel.terminalBridge,
                             onStartSession = { viewModel.startTerminalSession() },
                             onStopSession = { viewModel.stopTerminalSession() },
                             defaultLoginUser = defaultUser,
                             fontSizeSp = fontSize,
-                            fontFamilyName = fontFamily
+                            fontFamilyName = fontFamily,
+                            isKeepScreenOnEnabled = isKeepScreenOnEnabled
                         )
                     }
 
@@ -209,6 +211,7 @@ fun MainAppContent(viewModel: MainViewModel) {
                         val fontSize by viewModel.terminalFontSize.collectAsState()
                         val fontFamily by viewModel.terminalFontFamily.collectAsState()
                         val isKeepAliveEnabled by viewModel.isKeepAliveEnabled.collectAsState()
+                        val isKeepScreenOnEnabled by viewModel.isKeepScreenOnEnabled.collectAsState()
                         SettingsScreen(
                             state = dashboardState,
                             backupState = backupState,
@@ -218,6 +221,8 @@ fun MainAppContent(viewModel: MainViewModel) {
                             terminalFontFamily = fontFamily,
                             isKeepAliveEnabled = isKeepAliveEnabled,
                             onToggleKeepAlive = { viewModel.toggleKeepAlive() },
+                            isKeepScreenOnEnabled = isKeepScreenOnEnabled,
+                            onSetKeepScreenOn = { enabled -> viewModel.setKeepScreenOnEnabled(enabled) },
                             onSelectTheme = { themeId -> viewModel.setTerminalTheme(themeId) },
                             onUpdateCustomTheme = { fg, bg, cursor, sel, ansi ->
                                 viewModel.updateCustomTheme(fg, bg, cursor, sel, ansi)

--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainViewModel.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainViewModel.kt
@@ -132,6 +132,18 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    private fun loadKeepScreenOnEnabled(): Boolean {
+        return prefs.getBoolean("terminal_keep_screen_on", true)
+    }
+
+    private val _isKeepScreenOnEnabled = MutableStateFlow(loadKeepScreenOnEnabled())
+    val isKeepScreenOnEnabled: StateFlow<Boolean> = _isKeepScreenOnEnabled.asStateFlow()
+
+    fun setKeepScreenOnEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("terminal_keep_screen_on", enabled).apply()
+        _isKeepScreenOnEnabled.value = enabled
+    }
+
     private val _requestedScreen = MutableStateFlow<AppScreen?>(null)
     val requestedScreen: StateFlow<AppScreen?> = _requestedScreen.asStateFlow()
 

--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/settings/SettingsScreen.kt
@@ -186,7 +186,9 @@ fun SettingsScreen(
     onUpgradeRootfsClick: () -> Unit = {},
     onDismissBackupStatus: () -> Unit = {},
     isKeepAliveEnabled: Boolean = true,
-    onToggleKeepAlive: () -> Unit = {}
+    onToggleKeepAlive: () -> Unit = {},
+    isKeepScreenOnEnabled: Boolean = true,
+    onSetKeepScreenOn: (Boolean) -> Unit = {}
 ) {
     val context = LocalContext.current
     val contentResolver = context.contentResolver
@@ -540,6 +542,28 @@ fun SettingsScreen(
                     Switch(
                         checked = isKeepAliveEnabled,
                         onCheckedChange = { onToggleKeepAlive() }
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            stringResource(R.string.setting_keep_screen_on_title),
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            stringResource(R.string.setting_keep_screen_on_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = isKeepScreenOnEnabled,
+                        onCheckedChange = { onSetKeepScreenOn(it) }
                     )
                 }
 

--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/terminal/TerminalScreen.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/terminal/TerminalScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -36,12 +37,27 @@ fun TerminalScreen(
     onStopSession: () -> Unit,
     defaultLoginUser: String = "root",
     fontSizeSp: Int = 13,
-    fontFamilyName: String = TerminalFonts.DEFAULT_FONT
+    fontFamilyName: String = TerminalFonts.DEFAULT_FONT,
+    isKeepScreenOnEnabled: Boolean = true
 ) {
     val context = LocalContext.current
+    val view = LocalView.current
     val clipboardManager = LocalClipboardManager.current
     val isRunning by terminalBridge.isRunning.collectAsStateWithLifecycle()
     val refreshTrigger by terminalBridge.refreshTrigger.collectAsStateWithLifecycle()
+
+    // Keep the display awake during active sessions (issue #25)
+    DisposableEffect(isKeepScreenOnEnabled, isRunning) {
+        val shouldKeepScreenOn = isKeepScreenOnEnabled && isRunning
+        if (shouldKeepScreenOn) {
+            view.keepScreenOn = true
+        }
+        onDispose {
+            if (shouldKeepScreenOn) {
+                view.keepScreenOn = false
+            }
+        }
+    }
 
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -28,6 +28,8 @@
     <string name="notification_status_nginx_active">NGINX-Server auf :80</string>
     <string name="setting_keep_alive_title">Hintergrund-Ausführung &amp; WakeLock</string>
     <string name="setting_keep_alive_desc">Führt einen Foreground Service mit partiellem CPU-WakeLock aus, um das Beenden von Kompilierungen, SSH-Servern oder Terminal-Sitzungen durch Android Doze zu verhindern.</string>
+    <string name="setting_keep_screen_on_title">Display aktiv halten, solange das Terminal läuft</string>
+    <string name="setting_keep_screen_on_desc">Hält den Bildschirm wach, während eine Terminal-Sitzung angezeigt wird, damit lang laufende Aufgaben ohne Berührung sichtbar bleiben.</string>
 
     <!-- Navigation Tabs -->
     <string name="nav_dashboard">Übersicht</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="notification_status_nginx_active">NGINX server on :80</string>
     <string name="setting_keep_alive_title">Background Execution &amp; WakeLock</string>
     <string name="setting_keep_alive_desc">Runs a persistent foreground service with partial CPU WakeLock to prevent Android Doze and Phantom Process Killer from terminating compilations, SSH servers, or terminal sessions.</string>
+    <string name="setting_keep_screen_on_title">Keep Screen On While Terminal Is Active</string>
+    <string name="setting_keep_screen_on_desc">Keeps the display awake while a terminal session is on screen, so long running tasks stay visible without needing to touch the screen.</string>
 
     <!-- Navigation Tabs -->
     <string name="nav_dashboard">Dashboard</string>


### PR DESCRIPTION
Fixes #25

When you're watching a long build or tailing logs in the terminal the phone times out and locks mid session which gets old real quick so this keeps the display awake while the terminal tab is open and a session is actually running

What it does
- sets the keepScreenOn flag on the terminal view, clears it again when you stop the session leave the tab or flip the new setting off
- adds a toggle under Settings > Background Execution right next to the wakelock switch, default on, persisted like every other setting
- strings for en and de included

One scoping note: i tied it to the terminal being visible on purpose. Android stops honoring FLAG_KEEP_SCREEN_ON once the app is in background anyway and ssh surviving in the background is already covered by the foreground service wakelock so keeping the screen lit then would just burn battery for nothing

Verified with unit tests plus assembleDebug through CI on my fork and tested on an actual device