### PR TITLE
Add startup sanity check with slow-mode splash escape hatch

### DIFF
--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainAppContent.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainAppContent.kt
@@ -43,6 +43,7 @@ fun MainAppContent(viewModel: MainViewModel) {
 
     val isInitializing = dashboardState.isInitializing
     val isInstalled = dashboardState.isInstalled
+    val splashDismissed = dashboardState.splashDismissed
     var currentScreen by remember { mutableStateOf(AppScreen.SPLASH) }
 
     LaunchedEffect(requestedScreen) {
@@ -53,9 +54,9 @@ fun MainAppContent(viewModel: MainViewModel) {
     }
 
     // Sync screen navigation state when initialization completes or installation status is confirmed
-    LaunchedEffect(isInitializing, isInstalled) {
+    LaunchedEffect(isInitializing, isInstalled, splashDismissed) {
         if (!isInitializing) {
-            if (!isInstalled) {
+            if (!isInstalled && !splashDismissed) {
                 currentScreen = AppScreen.WIZARD
             } else if (currentScreen == AppScreen.SPLASH || currentScreen == AppScreen.WIZARD) {
                 currentScreen = AppScreen.DASHBOARD
@@ -64,13 +65,12 @@ fun MainAppContent(viewModel: MainViewModel) {
     }
 
     if (isInitializing || currentScreen == AppScreen.SPLASH) {
-        val statusText = stringResource(dashboardState.initStep.stringResId)
-        SplashScreen(statusText = statusText)
+        SplashRoute(viewModel, dashboardState)
     } else {
         Scaffold(
             bottomBar = {
                 val isImeVisible = WindowInsets.isImeVisible
-                if (isInstalled && currentScreen != AppScreen.WIZARD && !(currentScreen == AppScreen.TERMINAL && isImeVisible)) {
+                if ((isInstalled || splashDismissed) && currentScreen != AppScreen.WIZARD && !(currentScreen == AppScreen.TERMINAL && isImeVisible)) {
                     NavigationBar {
                         NavigationBarItem(
                             selected = currentScreen == AppScreen.DASHBOARD,
@@ -137,8 +137,7 @@ fun MainAppContent(viewModel: MainViewModel) {
             ) {
                 when (currentScreen) {
                     AppScreen.SPLASH -> {
-                        val statusText = stringResource(dashboardState.initStep.stringResId)
-                        SplashScreen(statusText = statusText)
+                        SplashRoute(viewModel, dashboardState)
                     }
 
                     AppScreen.WIZARD -> {
@@ -268,4 +267,15 @@ fun MainAppContent(viewModel: MainViewModel) {
             )
         }
     }
+}
+
+@Composable
+private fun SplashRoute(viewModel: MainViewModel, state: DashboardUiState) {
+    SplashScreen(
+        statusText = stringResource(state.initStep.stringResId),
+        initSlow = state.isInitSlow,
+        elapsedSeconds = (state.initElapsedMs / 1000L).toInt(),
+        onRetry = { viewModel.retryInit() },
+        onContinueAnyway = { viewModel.dismissSplash() }
+    )
 }

--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainViewModel.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/MainViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 import com.devwithzachary.completelinuxinstaller.R
@@ -37,9 +38,14 @@ enum class InitStep(val stringResId: Int) {
     PREPARING_ENVIRONMENT(R.string.splash_init_preparing)
 }
 
+private const val INIT_SLOW_THRESHOLD_MS = 10_000L
+private const val TAG = "MainViewModel"
+
 data class DashboardUiState(
     val isInitializing: Boolean = true,
     val initStep: InitStep = InitStep.VERIFYING_BINARIES,
+    val initElapsedMs: Long = 0L,
+    val splashDismissed: Boolean = false,
     val isInstalled: Boolean = false,
     val storageUsedMb: Long = 0L,
     val distroName: String = "Ubuntu 26.04 LTS (ARM64/x86_64)",
@@ -53,7 +59,9 @@ data class DashboardUiState(
     val isUpgradeAvailable: Boolean = false,
     val dnsServers: List<String> = listOf("8.8.8.8", "1.1.1.1", "8.8.4.4"),
     val containerUsers: List<String> = emptyList()
-)
+) {
+    val isInitSlow: Boolean get() = initElapsedMs >= INIT_SLOW_THRESHOLD_MS
+}
 
 sealed class BackupState {
     data object Idle : BackupState()
@@ -233,26 +241,75 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _defaultTerminalUser.value = username
     }
 
+    private var initJob: kotlinx.coroutines.Job? = null
+    private var initGeneration = 0
+
+    fun dismissSplash() {
+        initGeneration++
+        _dashboardState.value = _dashboardState.value.copy(
+            isInitializing = false,
+            splashDismissed = true
+        )
+    }
+
+    fun retryInit() {
+        _dashboardState.value = _dashboardState.value.copy(
+            isInitializing = true,
+            splashDismissed = false,
+            initElapsedMs = 0L
+        )
+        startInitialization()
+    }
+
+    private fun startInitialization() {
+        val gen = ++initGeneration
+        val startMs = System.currentTimeMillis()
+        initJob?.cancel()
+        initJob = viewModelScope.launch {
+            val watchdog = launch {
+                while (isActive && _dashboardState.value.isInitializing) {
+                    kotlinx.coroutines.delay(1000)
+                    val elapsed = System.currentTimeMillis() - startMs
+                    if (!_dashboardState.value.isInitializing) break
+                    _dashboardState.value = _dashboardState.value.copy(
+                        initElapsedMs = elapsed
+                    )
+                }
+            }
+            try {
+                _dashboardState.value = _dashboardState.value.copy(initStep = InitStep.VERIFYING_BINARIES)
+                pRootEngine.ensurePRootExecutable()
+                kotlinx.coroutines.delay(200)
+
+                _dashboardState.value = _dashboardState.value.copy(initStep = InitStep.CHECKING_FILESYSTEM)
+                refreshStatusInternal()
+                kotlinx.coroutines.delay(250)
+
+                _dashboardState.value = _dashboardState.value.copy(initStep = InitStep.PREPARING_ENVIRONMENT)
+                kotlinx.coroutines.delay(250)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Startup initialization failed", e)
+            } finally {
+                watchdog.cancel()
+                if (gen == initGeneration) {
+                    _dashboardState.value = _dashboardState.value.copy(
+                        isInitializing = false,
+                        initElapsedMs = System.currentTimeMillis() - startMs
+                    )
+                }
+            }
+        }
+    }
+
     init {
         PRootForegroundService.isTerminalActiveProvider = { terminalBridge.isRunning.value }
         PRootForegroundService.rootfsDirProvider = { pRootEngine.rootfsDir }
         PRootForegroundService.sshPortProvider = { _sshPort.value }
         PRootForegroundService.onStopSessionRequested = { stopTerminalSession() }
 
-        viewModelScope.launch {
-            _dashboardState.value = _dashboardState.value.copy(initStep = InitStep.VERIFYING_BINARIES)
-            pRootEngine.ensurePRootExecutable()
-            kotlinx.coroutines.delay(200)
-
-            _dashboardState.value = _dashboardState.value.copy(initStep = InitStep.CHECKING_FILESYSTEM)
-            refreshStatusInternal()
-            kotlinx.coroutines.delay(250)
-
-            _dashboardState.value = _dashboardState.value.copy(initStep = InitStep.PREPARING_ENVIRONMENT)
-            kotlinx.coroutines.delay(250)
-
-            _dashboardState.value = _dashboardState.value.copy(isInitializing = false)
-        }
+        startInitialization()
     }
 
     private fun loadTerminalTheme(): TerminalTheme {

--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/splash/SplashScreen.kt
@@ -25,7 +25,11 @@ import com.devwithzachary.completelinuxinstaller.R
 
 @Composable
 fun SplashScreen(
-    statusText: String = stringResource(R.string.splash_init_verifying_binaries)
+    statusText: String = stringResource(R.string.splash_init_verifying_binaries),
+    initSlow: Boolean = false,
+    elapsedSeconds: Int = 0,
+    onRetry: () -> Unit = {},
+    onContinueAnyway: () -> Unit = {}
 ) {
     val infiniteTransition = rememberInfiniteTransition(label = "pulse")
     val scale by infiniteTransition.animateFloat(
@@ -162,6 +166,36 @@ fun SplashScreen(
                 color = Color(0xFFBAC2DE),
                 modifier = Modifier.alpha(alpha)
             )
+
+            if (initSlow) {
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Surface(
+                    shape = MaterialTheme.shapes.medium,
+                    color = Color(0xFFF38BA8).copy(alpha = 0.12f),
+                    contentColor = Color(0xFFF38BA8)
+                ) {
+                    Text(
+                        text = stringResource(R.string.splash_init_slow_warning, elapsedSeconds),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedButton(onClick = onRetry) {
+                        Text(stringResource(R.string.splash_retry))
+                    }
+                    Button(onClick = onContinueAnyway) {
+                        Text(stringResource(R.string.splash_continue_anyway))
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,6 +14,9 @@
     <string name="splash_init_verifying_binaries">CPU-Architektur &amp; PRoot-Binaries werden überprüft…</string>
     <string name="splash_init_checking_filesystem">Linux-RootFS &amp; Speicher werden überprüft…</string>
     <string name="splash_init_preparing">Container-Umgebung wird vorbereitet…</string>
+    <string name="splash_init_slow_warning">Der Start dauert länger als erwartet (%1$d s). Das RootFS ist möglicherweise beschädigt oder ausgelastet.</string>
+    <string name="splash_retry">Wiederholen</string>
+    <string name="splash_continue_anyway">Trotzdem fortfahren</string>
 
     <!-- Foreground Service & Resource Monitor -->
     <string name="notification_channel_name">Linux Container &amp; Service-Monitor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="splash_init_verifying_binaries">Verifying CPU architecture &amp; PRoot binaries…</string>
     <string name="splash_init_checking_filesystem">Checking Linux rootfs filesystem &amp; storage…</string>
     <string name="splash_init_preparing">Preparing container environment…</string>
+    <string name="splash_init_slow_warning">Startup is taking longer than expected (%1$d s). The rootfs may be busy or damaged.</string>
+    <string name="splash_retry">Retry</string>
+    <string name="splash_continue_anyway">Continue anyway</string>
 
     <!-- Foreground Service & Resource Monitor -->
     <string name="notification_channel_name">Linux Container &amp; Service Monitor</string>


### PR DESCRIPTION
Motivated by #29, where users got stuck on the splash screen indefinitely. Implements items 1 and 2 of #30. Items 3 and 4 (health check button, debug log) are left for follow-up work.

What changed:

- The splash now tracks how long init takes. Past 10 seconds it shows "Startup is taking longer than expected (N s)" with Retry and Continue anyway buttons.
- Init runs inside try/catch/finally now. Before this, an exception in ensurePRootExecutable() or refreshStatusInternal() would kill the coroutine and leave isInitializing=true forever, which I believe is what produced the #29 loops.
- Continue anyway drops the splash while init keeps running in the background. When it finishes, results fill in without bouncing the user anywhere.
- After dismissal the bottom navigation stays visible, so Settings and Terminal remain reachable even if the status refresh never completed. That was the intent of item 2: get into the app at all to attempt a repair instead of wiping app data from Android settings.
- A generation counter guards the init sequence so retry/dismiss races can't clobber fresh state with stale results.

Testing: unit tests pass and the APK builds through GitHub Actions. Manually checked normal boots, forced-hang flows, retry, dismissal, and first-run wizard routing.
