### PR TITLE
Keep screen on while setup wizard is visible

### DIFF
--- a/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/wizard/WizardScreen.kt
+++ b/app/src/main/java/com/devwithzachary/completelinuxinstaller/ui/screens/wizard/WizardScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -52,6 +53,12 @@ fun WizardScreen(
     var rootPassword by remember { mutableStateOf("root") }
     var username by remember { mutableStateOf("ubuntu") }
     var userPassword by remember { mutableStateOf("ubuntu") }
+
+    val view = LocalView.current
+    DisposableEffect(Unit) {
+        view.keepScreenOn = true
+        onDispose { view.keepScreenOn = false }
+    }
 
     Column(
         modifier = Modifier


### PR DESCRIPTION
On first launch the setup wizard can sit for several minutes while the rootfs downloads. If the screen locks partway through, the user has to unlock and reopen every time.

This keeps the screen awake while the wizard screen is composed, via view.keepScreenOn in a DisposableEffect. Same approach TerminalScreen already uses. One file, seven lines, flag clears on exit.
